### PR TITLE
Use HTTPS instead of HTTP to resolve dependencies

### DIFF
--- a/cermine-tools/pom.xml
+++ b/cermine-tools/pom.xml
@@ -65,7 +65,7 @@
         <repository>
             <id>google-maven-repository</id>
             <name>Google Maven Repository</name>
-            <url>http://google-maven-repository.googlecode.com/svn/repository/</url>
+            <url>https://google-maven-repository.googlecode.com/svn/repository/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <repository>
             <id>yadda</id>
             <name>YADDA project repository</name>
-            <url>http://maven.icm.edu.pl/artifactory/repo</url>
+            <url>https://maven.icm.edu.pl/artifactory/repo</url>
         </repository>
     </repositories>
     <dependencyManagement>
@@ -155,11 +155,11 @@
     <distributionManagement>
         <repository>
             <id>kdd-releases</id>
-            <url>http://maven.ceon.pl/artifactory/kdd-releases</url>
+            <url>https://maven.ceon.pl/artifactory/kdd-releases</url>
         </repository>
         <snapshotRepository>
             <id>kdd-snapshots</id>
-            <url>http://maven.ceon.pl/artifactory/kdd-snapshots</url>
+            <url>https://maven.ceon.pl/artifactory/kdd-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
This fixes a security vulnerability in this project where the `pom.xml`
files were configuring Maven to resolve dependencies over HTTP instead of
HTTPS.

Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>